### PR TITLE
Fix typo in figlet header parsing comment

### DIFF
--- a/Sources/SwiftFigletKit/SFKFigletFile.swift
+++ b/Sources/SwiftFigletKit/SFKFigletFile.swift
@@ -67,7 +67,7 @@ public struct SFKFigletFile {
     public let fullLayout: Int
     public let codeTagCount: Int
 
-    /// Returns a Header from String passed. If can't create it bacause `from` does not follow
+    /// Returns a Header from String passed. If can't create it because `from` does not follow
     /// Figlet header format, returns `nil`
     /// - Parameter header: first line from a Figlet font file
     public static func createFigletFontHeader(from header: String) -> Self? {


### PR DESCRIPTION
## Summary
- fix typo in Figlet file header parsing comment

## Testing
- `codespell --skip "*.flf" --ignore-words-list "neer,jave,caligraphy"`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_689e3201f4fc8333a140569bf477344d