### PR TITLE
Site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@
 xcuserdata/
 SwiftFiglet/SwiftFiglet/SwiftFiglet.xcodeproj/project.xcworkspace/contents.xcworkspacedata
 SwiftFiglet/SwiftFiglet/SwiftFiglet.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+
+# DoCC 
+	
+**/.docc-build/**
+**/.docc-derived/**
+**/.docc-publish/**

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+</Workspace>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/SwiftFigletKit.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/SwiftFigletKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1620"
+   LastUpgradeVersion = "2600"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Docs/Fonts-README.md
+++ b/Docs/Fonts-README.md
@@ -8,4 +8,3 @@ my collection of ascii art fonts for [figlet](http://www.figlet.org/) or
 [toilet](http://caca.zoy.org/wiki/toilet).
 
 install files to `/usr/share/figlet/` or `/usr/share/figlet/fonts/`.
-

--- a/Docs/Fonts-README.md
+++ b/Docs/Fonts-README.md
@@ -8,3 +8,4 @@ my collection of ascii art fonts for [figlet](http://www.figlet.org/) or
 [toilet](http://caca.zoy.org/wiki/toilet).
 
 install files to `/usr/share/figlet/` or `/usr/share/figlet/fonts/`.
+

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "96e5821b55a64c145747d4383ed605cf56dcbfc9f546386e9d3bdea8f4b9d6de",
+  "originHash" : "bc89c6e629041f24117501df03691af3d4ac7c920c45170ab9b89e5a1a00411f",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
@@ -8,6 +8,24 @@
       "state" : {
         "revision" : "309a47b2b1d9b5e991f36961c983ecec72275be3",
         "version" : "1.6.1"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "3e4f133a77e644a5812911a0513aeb7288b07d06",
+        "version" : "1.4.5"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "96e5821b55a64c145747d4383ed605cf56dcbfc9f546386e9d3bdea8f4b9d6de",
+  "originHash" : "83160da3d4c60201f4f91f573dcaedb4b6b1d8693e6f4d414a73ce77f1ba0525",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
@@ -8,6 +8,51 @@
       "state" : {
         "revision" : "309a47b2b1d9b5e991f36961c983ecec72275be3",
         "version" : "1.6.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
+        "version" : "1.6.4"
+      }
+    },
+    {
+      "identity" : "swift-subprocess",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-subprocess.git",
+      "state" : {
+        "revision" : "44be5d56aa4b26dc2003a67c0288a6a68366a87d",
+        "version" : "0.1.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system",
+      "state" : {
+        "revision" : "61e4ca4b81b9e09e2ec863b00c340eb13497dac6",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-tools-support-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-tools-support-core.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "a00f2e3c7c80595ecea990206b9024ebaa767613"
+      }
+    },
+    {
+      "identity" : "xmlcoder",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CoreOffice/XMLCoder.git",
+      "state" : {
+        "revision" : "b1e944cbd0ef33787b13f639a5418d55b3bed501",
+        "version" : "0.17.1"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "96e5821b55a64c145747d4383ed605cf56dcbfc9f546386e9d3bdea8f4b9d6de",
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "309a47b2b1d9b5e991f36961c983ecec72275be3",
+        "version" : "1.6.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "83160da3d4c60201f4f91f573dcaedb4b6b1d8693e6f4d414a73ce77f1ba0525",
+  "originHash" : "96e5821b55a64c145747d4383ed605cf56dcbfc9f546386e9d3bdea8f4b9d6de",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
@@ -8,51 +8,6 @@
       "state" : {
         "revision" : "309a47b2b1d9b5e991f36961c983ecec72275be3",
         "version" : "1.6.1"
-      }
-    },
-    {
-      "identity" : "swift-log",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-log.git",
-      "state" : {
-        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
-        "version" : "1.6.4"
-      }
-    },
-    {
-      "identity" : "swift-subprocess",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-subprocess.git",
-      "state" : {
-        "revision" : "44be5d56aa4b26dc2003a67c0288a6a68366a87d",
-        "version" : "0.1.0"
-      }
-    },
-    {
-      "identity" : "swift-system",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-system",
-      "state" : {
-        "revision" : "61e4ca4b81b9e09e2ec863b00c340eb13497dac6",
-        "version" : "1.5.0"
-      }
-    },
-    {
-      "identity" : "swift-tools-support-core",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-tools-support-core.git",
-      "state" : {
-        "branch" : "main",
-        "revision" : "a00f2e3c7c80595ecea990206b9024ebaa767613"
-      }
-    },
-    {
-      "identity" : "xmlcoder",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CoreOffice/XMLCoder.git",
-      "state" : {
-        "revision" : "b1e944cbd0ef33787b13f639a5418d55b3bed501",
-        "version" : "0.17.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,8 @@ let package: Package = .init(
     .executable(name: "swift-figlet-cli", targets: ["SwiftFigletCLI"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0")
+    .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
+    .package(name: "SystemScheduler", path: "../SystemScheduler"),
   ],
   targets: [
     .target(
@@ -32,6 +33,7 @@ let package: Package = .init(
       dependencies: [
         "SwiftFigletKit",
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
+        .product(name: "SystemScheduler", package: "SystemScheduler"),
       ]
     ),
     .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package: Package = .init(
   ],
   products: [
     .library(name: "SwiftFigletKit", targets: ["SwiftFigletKit"]),
-    .executable(name: "swiftfiglet", targets: ["SwiftFigletCLI"]),
+    .executable(name: "swiftfiglet-cli", targets: ["SwiftFigletCLI"]),
   ],
   dependencies: [
     // Dependencies declare other packages that this package depends on.

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,8 @@ let package: Package = .init(
     .watchOS(.v9),
   ],
   products: [
-    .library(name: "SwiftFigletKit", targets: ["SwiftFigletKit"])
+    .library(name: "SwiftFigletKit", targets: ["SwiftFigletKit"]),
+    .executable(name: "swiftfiglet", targets: ["SwiftFigletCLI"]),
   ],
   dependencies: [
     // Dependencies declare other packages that this package depends on.
@@ -26,6 +27,10 @@ let package: Package = .init(
       swiftSettings: [
         .define("SIMULATOR", .when(platforms: [.iOS], configuration: .debug))
       ],
+    ),
+    .executableTarget(
+      name: "SwiftFigletCLI",
+      dependencies: ["SwiftFigletKit"]
     ),
     .testTarget(
       name: "SwiftFigletKitTests",

--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,7 @@ let package: Package = .init(
     .target(
       name: "SwiftFigletKit",
       dependencies: [],
+      exclude: ["Resources/README.md"],
       resources: [
         .copy("Resources/Fonts")
       ],
@@ -35,6 +36,9 @@ let package: Package = .init(
     .testTarget(
       name: "SwiftFigletKitTests",
       dependencies: ["SwiftFigletKit"],
+      resources: [
+        .copy("SwiftFigletKitTests/testFonts")
+      ]
     ),
   ],
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.1
 import PackageDescription
 
 let package: Package = .init(

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,6 @@ let package: Package = .init(
     .target(
       name: "SwiftFigletKit",
       dependencies: [],
-      exclude: ["Resources/README.md"],
       resources: [
         .copy("Resources/Fonts")
       ],

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,8 @@ let package: Package = .init(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
+    // DocC plugin enables `swift package generate-documentation`
+    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0"),
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,6 @@ let package: Package = .init(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
-    .package(name: "SystemScheduler", path: "../SystemScheduler"),
   ],
   targets: [
     .target(
@@ -33,7 +32,6 @@ let package: Package = .init(
       dependencies: [
         "SwiftFigletKit",
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
-        .product(name: "SystemScheduler", package: "SystemScheduler"),
       ]
     ),
     .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -25,11 +25,11 @@ let package: Package = .init(
       ],
       swiftSettings: [
         .define("SIMULATOR", .when(platforms: [.iOS], configuration: .debug))
-      ]
+      ],
     ),
     .testTarget(
       name: "SwiftFigletKitTests",
-      dependencies: ["SwiftFigletKit"]
+      dependencies: ["SwiftFigletKit"],
     ),
-  ]
+  ],
 )

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package: Package = .init(
     .executable(name: "swift-figlet-cli", targets: ["SwiftFigletCLI"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
+    .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0")
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -11,11 +11,10 @@ let package: Package = .init(
   ],
   products: [
     .library(name: "SwiftFigletKit", targets: ["SwiftFigletKit"]),
-    .executable(name: "swiftfiglet-cli", targets: ["SwiftFigletCLI"]),
+    .executable(name: "swift-figlet-cli", targets: ["SwiftFigletCLI"]),
   ],
   dependencies: [
-    // Dependencies declare other packages that this package depends on.
-    // .package(url: /* package url */, from: "1.0.0"),
+    .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
   ],
   targets: [
     .target(
@@ -30,7 +29,10 @@ let package: Package = .init(
     ),
     .executableTarget(
       name: "SwiftFigletCLI",
-      dependencies: ["SwiftFigletKit"]
+      dependencies: [
+        "SwiftFigletKit",
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
+      ]
     ),
     .testTarget(
       name: "SwiftFigletKitTests",

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package: Package = .init(
       name: "SwiftFigletKitTests",
       dependencies: ["SwiftFigletKit"],
       resources: [
-        .copy("SwiftFigletKitTests/testFonts")
+        .copy("testFonts")
       ]
     ),
   ],

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ CLI
   - `swift build --package-path . -c release`
 - Usage:
   - `swift run --package-path . swift-figlet-cli --list-fonts`
+  - `swift run --package-path . swift-figlet-cli --random-font` (prints one random font name)
   - `swift run --package-path . swift-figlet-cli --font Standard "Hello World"`
+  - `swift run --package-path . swift-figlet-cli --font random "Hello World"` (renders with a random font)
   - `echo hello | swift run --package-path . swift-figlet-cli --font Slant`
 
 Notes

--- a/README.md
+++ b/README.md
@@ -1,25 +1,28 @@
 # SwiftFigletKit
 
 ```
-  #####                                 #######                                        #    #           
- #     #  #    #  #  ######  #####      #        #   ####   #       ######  #####      #   #   #  ##### 
- #        #    #  #  #         #        #        #  #    #  #       #         #        #  #    #    #   
-  #####   #    #  #  #####     #        #####    #  #       #       #####     #        ###     #    #   
-       #  # ## #  #  #         #        #        #  #  ###  #       #         #        #  #    #    #   
- #     #  ##  ##  #  #         #        #        #  #    #  #       #         #        #   #   #    #   
-  #####   #    #  #  #         #        #        #   ####   ######  ######    #        #    #  #    #   
+  #####                                 #######                                        #    #
+ #     #  #    #  #  ######  #####      #        #   ####   #       ######  #####      #   #   #  #####
+ #        #    #  #  #         #        #        #  #    #  #       #         #        #  #    #    #
+  #####   #    #  #  #####     #        #####    #  #       #       #####     #        ###     #    #
+       #  # ## #  #  #         #        #        #  #  ###  #       #         #        #  #    #    #
+ #     #  ##  ##  #  #         #        #        #  #    #  #       #         #        #   #   #    #
+  #####   #    #  #  #         #        #        #   ####   ######  ######    #        #    #  #    #
 ```
 
-A simple library to read and display [banner](https://en.wikipedia.org/wiki/Banner_(Unix)) like ASCII art messages using [Figlet](http://www.figlet.org/) fonts 
+A simple library to read and display [banner](<https://en.wikipedia.org/wiki/Banner_(Unix)>) like
+ASCII art messages using [Figlet](http://www.figlet.org/) fonts
 
 ## Installation
 
 - Add FigletKit to your project using Swift Package Manager. From Xcode add this repo as a package.
-- Or clone this repo and copy over the required four files: `SFKFont`, `SFKChar`, `SFKBanner` and `SFKFigletFile`
+- Or clone this repo and copy over the required four files: `SFKFont`, `SFKChar`, `SFKBanner` and
+  `SFKFigletFile`
 
 ## Limitations
 
-- SwiftFigletKit targets Apple platforms (iOS, macOS, tvOS and watchOS) and prints to standard output.
+- SwiftFigletKit targets Apple platforms (iOS, macOS, tvOS and watchOS) and prints to standard
+  output.
 - Only Figlet font files are supported (.flf)
 - If you have trouble loading a flf file, open an issue and attach font file, please.
 
@@ -51,12 +54,13 @@ if let font = SFKFont.random() {
 - [x] Finish this README 😅
 - [x] add MIT license notice
 - [x] Add Swift Figlet File property as optional after loading a `SFKFont` from disk
-- [x] Remove [Toilet fonts](http://caca.zoy.org/wiki/toilet) from fonts sample dir: won't support them
-- [ ] Add support for lines adding Unicode character to be loaded, like  `196  LATIN CAPITAL LETTER A WITH DIAERESIS`, see Banner.flf
+- [x] Remove [Toilet fonts](http://caca.zoy.org/wiki/toilet) from fonts sample dir: won't support
+      them
+- [ ] Add support for lines adding Unicode character to be loaded, like
+      `196  LATIN CAPITAL LETTER A WITH DIAERESIS`, see Banner.flf
 - [x] test font `Wow.flf` with mixed line endings (`CR/LF` and `CR`)
 - [ ] adapt file loading for iOS
-- [ ] honor right to left print direction 
-
+- [ ] honor right to left print direction
 
 ## Fonts used
 

--- a/README.md
+++ b/README.md
@@ -1,71 +1,11 @@
-# SwiftFigletKit
-
 ```
-  #####                                 #######                                        #    #
- #     #  #    #  #  ######  #####      #        #   ####   #       ######  #####      #   #   #  #####
- #        #    #  #  #         #        #        #  #    #  #       #         #        #  #    #    #
-  #####   #    #  #  #####     #        #####    #  #       #       #####     #        ###     #    #
-       #  # ## #  #  #         #        #        #  #  ###  #       #         #        #  #    #    #
- #     #  ##  ##  #  #         #        #        #  #    #  #       #         #        #   #   #    #
-  #####   #    #  #  #         #        #        #   ####   ######  ######    #        #    #  #    #
+┏━╸╻┏━╸╻  ┏━╸╺┳╸   ┏━╸┏━┓┏┓╻╺┳╸┏━┓
+┣╸ ┃┃╺┓┃  ┣╸  ┃    ┣╸ ┃ ┃┃┗┫ ┃ ┗━┓
+╹  ╹┗━┛┗━╸┗━╸ ╹    ╹  ┗━┛╹ ╹ ╹ ┗━┛
 ```
 
-A simple library to read and display [banner](<https://en.wikipedia.org/wiki/Banner_(Unix)>) like
-ASCII art messages using [Figlet](http://www.figlet.org/) fonts
+A collection of ASCII art fonts for Figlet.
 
-## Installation
-
-- Add FigletKit to your project using Swift Package Manager. From Xcode add this repo as a package.
-- Or clone this repo and copy over the required four files: `SFKFont`, `SFKChar`, `SFKBanner` and
-  `SFKFigletFile`
-
-## Limitations
-
-- SwiftFigletKit targets Apple platforms (iOS, macOS, tvOS and watchOS) and prints to standard
-  output.
-- Only Figlet font files are supported (.flf)
-- If you have trouble loading a flf file, open an issue and attach font file, please.
-
-## How to Use
-
-- Load a bundled `SFKFont`
-
-```swift
-import SwiftFigletKit
-
-if let url = Bundle.module.url(forResource: "starwars", withExtension: "flf", subdirectory: "Fonts"),
-   let font = SFKFont.from(url: url) {
-  print(string: "Swift Figlet Kit", usingFont: font)
-}
-```
-
-- Or let the package choose a random bundled font for you
-
-```swift
-if let font = SFKFont.random() {
-  print(string: "Swift Figlet Kit", usingFont: font)
-}
-```
-
-- No step 3. Told you it was a simple library 😅
-
-## TODO
-
-- [x] Finish this README 😅
-- [x] add MIT license notice
-- [x] Add Swift Figlet File property as optional after loading a `SFKFont` from disk
-- [x] Remove [Toilet fonts](http://caca.zoy.org/wiki/toilet) from fonts sample dir: won't support
-      them
-- [ ] Add support for lines adding Unicode character to be loaded, like
-      `196  LATIN CAPITAL LETTER A WITH DIAERESIS`, see Banner.flf
-- [x] test font `Wow.flf` with mixed line endings (`CR/LF` and `CR`)
-- [ ] adapt file loading for iOS
-- [ ] honor right to left print direction
-
-## Fonts used
-
-I've used the Figlet fonts from [xero's](https://github.com/xero/figlet-fonts) repo
-
-## License
-
-MIT
+Note: In SwiftFigletKit these fonts are bundled as resources and consumed via
+`Bundle.module`. This README was moved to the package root to avoid SwiftPM
+resource warnings.

--- a/README.md
+++ b/README.md
@@ -23,3 +23,46 @@ Notes
 - Fonts are bundled as SwiftPM resources and discovered via `Bundle.module`.
 - The CLI uses Swift Argument Parser and supports long-form flags like
   `--font` and `--list-fonts`.
+
+Color and gradients
+-------------------
+
+SwiftFigletKit includes lightweight ANSI color helpers (disabled by default in Xcode environments)
+and simple gradient rendering across lines.
+
+Single color
+
+```swift
+import SwiftFigletKit
+
+if let s = SFKRenderer.render(text: "CLIA", fontName: "random", color: .magenta) {
+  print(s)
+}
+```
+
+Available colors: `.none, .black, .red, .green, .yellow, .blue, .magenta, .cyan, .white`.
+
+- Disable in Xcode sessions (default): `disableColorInXcode: true`
+- Force color even in Xcode: pass `forceColor: true` to render overloads.
+
+Line-by-line gradient
+
+```swift
+import SwiftFigletKit
+
+if let s = SFKRenderer.renderGradientLines(
+  text: "C.L.I.A.",
+  fontName: "random",
+  // optional custom palette; defaults to [.red,.yellow,.green,.cyan,.blue,.magenta]
+  palette: nil,
+  randomizePalette: true
+) {
+  print(s)
+}
+```
+
+Notes:
+
+- Color APIs return colored strings with ANSI escape codes. Terminals render these; some UIs (like
+  Xcode debug console) may not. Use `forceColor` to override suppression when needed.
+- Rendering functions remain backward compatible. If you don’t pass a color, output is unchanged.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ CLI
   - `swift run --package-path . swift-figlet-cli --font random "Hello World"` (renders with a random font)
   - `echo hello | swift run --package-path . swift-figlet-cli --font Slant`
 
+Docs
+
+- DocC: published on GitHub Pages at:
+  - https://wrkstrm.github.io/todo3/SwiftFigletKit/
+  - If publishing under a fork or different repo name, replace `wrkstrm/todo3` accordingly.
+
 Notes
 
 - Fonts are bundled as SwiftPM resources and discovered via `Bundle.module`.
@@ -65,3 +71,96 @@ Notes:
 - Color APIs return colored strings with ANSI escape codes. Terminals render these; some UIs (like
   Xcode debug console) may not. Use `forceColor` to override suppression when needed.
 - Rendering functions remain backward compatible. If you don’t pass a color, output is unchanged.
+
+## Random rendering (fonts + colors)
+
+SwiftFigletKit exposes high‑level APIs to pick random fonts and color strategies with optional
+seeding for deterministic output. Fallbacks ensure a plain ANSI‑colored line is returned even when
+FIGlet fonts are unavailable.
+
+Types
+
+- `SFKFontStrategy`: `.named("Slant")`, `.random(excluding: ["Standard"])`
+- `SFKColorStrategy`:
+  - `.single(.cyan)`
+  - `.singleRandom(palette: nil)`
+  - `.gradient(palette: [.red, .yellow, .green])`
+  - `.gradientRandom(palette: nil, shuffle: true)`
+  - `.mixedRandom(gradientProbability: 0.5)`
+- `SFKRenderOptions`: `prefix`, `suffix`, `newline`, `seed`, `forceColor`, `disableColorInXcode`
+
+APIs
+
+- `SFKRenderer.render(text:font:color:options:) -> String`
+- `SFKRenderer.renderRandomBanner(text:color:options:) -> String` // shorthand for `font: .random()`
+
+Examples
+
+Fixed font + single fixed color
+
+```swift
+import SwiftFigletKit
+
+let out = SFKRenderer.render(
+  text: "Hello",
+  font: .named("Slant"),
+  color: .single(.cyan),
+  options: .init(newline: true)
+)
+print(out)
+```
+
+Random font + single random color
+
+```swift
+let out = SFKRenderer.render(
+  text: "Hello",
+  font: .random(),
+  color: .singleRandom(),
+  options: .init()
+)
+```
+
+Random font + gradient palette
+
+```swift
+let out = SFKRenderer.render(
+  text: "Hello",
+  font: .random(),
+  color: .gradient(palette: [.red, .yellow, .green]),
+  options: .init(newline: true)
+)
+```
+
+Mixed random (50/50 single vs gradient)
+
+```swift
+let out = SFKRenderer.renderRandomBanner(
+  text: "Hello",
+  color: .mixedRandom(gradientProbability: 0.5)
+)
+```
+
+Seeded determinism
+
+```swift
+let seed: UInt64 = 42
+let a = SFKRenderer.renderRandomBanner(text: "Hello", options: .init(seed: seed))
+let b = SFKRenderer.renderRandomBanner(text: "Hello", options: .init(seed: seed))
+assert(a == b)
+```
+
+Excluding fonts when randomizing
+
+```swift
+let out = SFKRenderer.render(
+  text: "Hello",
+  font: .random(excluding: ["Slant", "Standard"]),
+  color: .singleRandom()
+)
+```
+
+Fallback behavior
+
+- If fonts/bundles are unavailable, APIs return a single ANSI‑colored line (no FIGlet art).
+- Gradient requests degrade to a single color (first color of the chosen palette).

--- a/README.md
+++ b/README.md
@@ -19,25 +19,29 @@ A simple library to read and display [banner](https://en.wikipedia.org/wiki/Bann
 
 ## Limitations
 
-- this is a macOS library, for CLI programs. Can be adapted for iOS.
+- SwiftFigletKit targets Apple platforms (iOS, macOS, tvOS and watchOS) and prints to standard output.
 - Only Figlet font files are supported (.flf)
 - If you have trouble loading a flf file, open an issue and attach font file, please.
 
 ## How to Use
 
-- Load a `SFKFont` with
+- Load a bundled `SFKFont`
 
 ```swift
-
 import SwiftFigletKit
- 
-let font = SFKFont.from(file: "fonts/starwars.flf")
+
+if let url = Bundle.module.url(forResource: "starwars", withExtension: "flf", subdirectory: "Fonts"),
+   let font = SFKFont.from(url: url) {
+  print(string: "Swift Figlet Kit", usingFont: font)
+}
 ```
 
-- Once loaded, you can start printing to the console using
+- Or let the package choose a random bundled font for you
 
 ```swift
-print(string: "Swift Figlet Kit", usingFont: font)
+if let font = SFKFont.random() {
+  print(string: "Swift Figlet Kit", usingFont: font)
+}
 ```
 
 - No step 3. Told you it was a simple library 😅

--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@
 
 A collection of ASCII art fonts for Figlet.
 
-Note: In SwiftFigletKit these fonts are bundled as resources and consumed via
-`Bundle.module`. This README was moved to the package root to avoid SwiftPM
-resource warnings.
+CLI
+
+- Product: `swift-figlet-cli`
+- Build:
+  - `swift build --package-path . -c release`
+- Usage:
+  - `swift run --package-path . swift-figlet-cli --list-fonts`
+  - `swift run --package-path . swift-figlet-cli --font Standard "Hello World"`
+  - `echo hello | swift run --package-path . swift-figlet-cli --font Slant`
+
+Notes
+
+- Fonts are bundled as SwiftPM resources and discovered via `Bundle.module`.
+- The CLI uses Swift Argument Parser and supports long-form flags like
+  `--font` and `--list-fonts`.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ Notes
 - The CLI uses Swift Argument Parser and supports long-form flags like
   `--font` and `--list-fonts`.
 
-Color and gradients
--------------------
+## Color and gradients
 
 SwiftFigletKit includes lightweight ANSI color helpers (disabled by default in Xcode environments)
 and simple gradient rendering across lines.

--- a/Sources/SwiftFigletCLI/SwiftFigletCLI.swift
+++ b/Sources/SwiftFigletCLI/SwiftFigletCLI.swift
@@ -8,7 +8,7 @@ struct SwiftFigletCLI: ParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "swift-figlet-cli",
     abstract: "Render text using bundled FIGlet fonts",
-    subcommands: [Greet.self, InstallFigletGreet.self]
+    subcommands: [Greet.self]
   )
 
   @Flag(name: .customLong("list-fonts"), help: "List bundled fonts and exit")
@@ -39,8 +39,8 @@ struct SwiftFigletCLI: ParsableCommand {
       return
     }
 
-    let inputText = text.isEmpty ? readStdinIfPiped() : text.joined(separator: " ")
-    guard let message = inputText, !message.isEmpty else {
+    let message = text.joined(separator: " ")
+    guard !message.isEmpty else {
       throw ValidationError("No text provided (arg or stdin).")
     }
 
@@ -118,68 +118,7 @@ struct Greet: ParsableCommand {
       "Outcome over output",
       "Focus beats luck",
       "Build for users",
-      "Calm is a superpower",
-      "Step into the arena",
-      "Today is a good day",
-      "Finish strong",
-      "Consistency compounds",
-      "Enjoy the journey",
     ]
     return phrases.randomElement()
   }
-}
-
-// Subcommand: install-figlet-greet (LaunchAgent installer using library)
-struct InstallFigletGreet: AsyncParsableCommand {
-  static let configuration = CommandConfiguration(
-    commandName: "install-figlet-greet",
-    abstract: "Install a daily LaunchAgent for any program (generic)"
-  )
-
-  @Option(name: .customLong("label"), help: "LaunchAgent label")
-  var label: String = "com.wrkstrm.figlet-greet"
-
-  @Option(name: .customLong("program"), help: "Program path to run (absolute)")
-  var program: String
-
-  @Option(name: .customLong("args"), help: "Program argument (repeatable)")
-  var args: [String] = []
-
-  @Option(name: .customLong("hour"), help: "Hour 0-23")
-  var hour: Int = 9
-
-  @Option(name: .customLong("min"), help: "Minute 0-59")
-  var minute: Int = 0
-
-  @Option(name: .customLong("stdout"), help: "Stdout log path")
-  var stdout: String = "~/Library/Logs/figlet-greet.log"
-
-  @Option(name: .customLong("stderr"), help: "Stderr log path")
-  var stderr: String = "~/Library/Logs/figlet-greet.err"
-
-  mutating func run() async throws {
-    let scheduler = SystemScheduler()
-    let dest = try await scheduler.installDaily(
-      label: label,
-      program: program,
-      args: args,
-      hour: hour,
-      minute: minute,
-      stdout: stdout,
-      stderr: stderr
-    )
-    print("Installed and loaded: \(dest)")
-    print("Logs: \(stdout) (and \(stderr))")
-  }
-}
-
-private func readStdinIfPiped() -> String? {
-  if isatty(fileno(stdin)) == 0 {
-    let data = FileHandle.standardInput.readDataToEndOfFile()
-    if let s = String(data: data, encoding: .utf8) {
-      let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
-      return trimmed.isEmpty ? nil : trimmed
-    }
-  }
-  return nil
 }

--- a/Sources/SwiftFigletCLI/SwiftFigletCLI.swift
+++ b/Sources/SwiftFigletCLI/SwiftFigletCLI.swift
@@ -1,7 +1,6 @@
 import ArgumentParser
 import Foundation
 import SwiftFigletKit
-import SystemScheduler
 
 @main
 struct SwiftFigletCLI: ParsableCommand {

--- a/Sources/SwiftFigletCLI/main.swift
+++ b/Sources/SwiftFigletCLI/main.swift
@@ -1,12 +1,14 @@
 import ArgumentParser
 import Foundation
 import SwiftFigletKit
+import SystemScheduler
 
 @main
 struct SwiftFigletCLI: ParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "swift-figlet-cli",
-    abstract: "Render text using bundled FIGlet fonts"
+    abstract: "Render text using bundled FIGlet fonts",
+    subcommands: [Greet.self, InstallFigletGreet.self]
   )
 
   @Flag(name: .customLong("list-fonts"), help: "List bundled fonts and exit")
@@ -59,6 +61,115 @@ struct SwiftFigletCLI: ParsableCommand {
     }
 
     print(string: message, usingFont: font)
+  }
+}
+
+// Subcommand: greet (random phrase with random font)
+struct Greet: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "greet",
+    abstract: "Print an encouraging phrase with a random FIGlet font"
+  )
+
+  @Argument(help: "Phrase to render (optional). If omitted, picks a random one.")
+  var phrase: [String] = []
+
+  mutating func run() throws {
+    let msg = phrase.isEmpty ? (randomPhrase() ?? "You’ve got this") : phrase.joined(separator: " ")
+    guard let ascii = SFKRenderer.render(text: msg, fontName: "random") else {
+      throw ValidationError("Failed to render with random font")
+    }
+    print(ascii)
+  }
+
+  func randomPhrase() -> String? {
+    let phrases = [
+      "You’ve got this",
+      "Keep going",
+      "One step at a time",
+      "Make it happen",
+      "Stay focused",
+      "Be bold today",
+      "Progress over perfection",
+      "Ship small, ship often",
+      "Trust the process",
+      "Create with purpose",
+      "Curiosity wins",
+      "Embrace the challenge",
+      "Iterate and learn",
+      "Your work matters",
+      "Solve one problem",
+      "Think clearly",
+      "Own the outcome",
+      "Small wins compound",
+      "Do the hard thing",
+      "Start where you are",
+      "Practice daily",
+      "Craft over chaos",
+      "Kindness is strength",
+      "Better every day",
+      "Stay the course",
+      "Earn momentum",
+      "Keep it simple",
+      "Clarity over cleverness",
+      "Design for delight",
+      "Move with intent",
+      "Learn, unlearn, relearn",
+      "Outcome over output",
+      "Focus beats luck",
+      "Build for users",
+      "Calm is a superpower",
+      "Step into the arena",
+      "Today is a good day",
+      "Finish strong",
+      "Consistency compounds",
+      "Enjoy the journey",
+    ]
+    return phrases.randomElement()
+  }
+}
+
+// Subcommand: install-figlet-greet (LaunchAgent installer using library)
+struct InstallFigletGreet: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "install-figlet-greet",
+    abstract: "Install a daily LaunchAgent for any program (generic)"
+  )
+
+  @Option(name: .customLong("label"), help: "LaunchAgent label")
+  var label: String = "com.wrkstrm.figlet-greet"
+
+  @Option(name: .customLong("program"), help: "Program path to run (absolute)")
+  var program: String
+
+  @Option(name: .customLong("args"), help: "Program argument (repeatable)")
+  var args: [String] = []
+
+  @Option(name: .customLong("hour"), help: "Hour 0-23")
+  var hour: Int = 9
+
+  @Option(name: .customLong("min"), help: "Minute 0-59")
+  var minute: Int = 0
+
+  @Option(name: .customLong("stdout"), help: "Stdout log path")
+  var stdout: String = "~/Library/Logs/figlet-greet.log"
+
+  @Option(name: .customLong("stderr"), help: "Stderr log path")
+  var stderr: String = "~/Library/Logs/figlet-greet.err"
+
+  mutating func run() async throws {
+    let scheduler = SystemScheduler()
+    let dest = try await scheduler.installDaily(
+      label: label,
+      program: program,
+      args: args,
+      hour: hour,
+      minute: minute,
+      stdout: stdout,
+      stderr: stderr
+    )
+    print("Installed and loaded: \(dest)")
+    print("Logs: \(stdout) (and \(stderr))")
   }
 }
 

--- a/Sources/SwiftFigletCLI/main.swift
+++ b/Sources/SwiftFigletCLI/main.swift
@@ -33,7 +33,7 @@ struct CLI {
   }
 
   static func printUsage() {
-    let exe = (CommandLine.arguments.first as NSString?)?.lastPathComponent ?? "swiftfiglet"
+    let exe = (CommandLine.arguments.first as NSString?)?.lastPathComponent ?? "swiftfiglet-cli"
     let msg = """
     Usage: \(exe) [options] <text>
 
@@ -106,4 +106,3 @@ func run() -> Int32 {
 }
 
 exit(run())
-

--- a/Sources/SwiftFigletCLI/main.swift
+++ b/Sources/SwiftFigletCLI/main.swift
@@ -1,58 +1,62 @@
 import Foundation
+import ArgumentParser
 import SwiftFigletKit
 
-struct CLI {
-  struct Options {
-    var listFonts = false
-    var fontName: String? = nil
-    var text: String? = nil
-  }
+@main
+struct SwiftFigletCLI: ParsableCommand {
+  static var configuration = CommandConfiguration(
+    commandName: "swift-figlet-cli",
+    abstract: "Render text using bundled FIGlet fonts"
+  )
 
-  static func parse(_ args: [String]) -> Options {
-    var opts = Options()
-    var i = 0
-    while i < args.count {
-      let a = args[i]
-      switch a {
-      case "-h", "--help":
-        printUsage()
-        exit(0)
-      case "-l", "--list-fonts":
-        opts.listFonts = true
-        i += 1
-      case "-f", "--font":
-        if i + 1 < args.count { opts.fontName = args[i + 1]; i += 2 } else { i += 1 }
-      default:
-        // Remaining args compose the text
-        let remaining = Array(args[i...])
-        opts.text = remaining.joined(separator: " ")
-        i = args.count
-      }
+  @Flag(name: .customLong("list-fonts"), help: "List bundled fonts and exit")
+  var listFonts: Bool = false
+
+  @Flag(name: .customLong("random-font"), help: "Print a random bundled font name and exit")
+  var randomFontOnly: Bool = false
+
+  @Option(name: .customLong("font"), help: "Font to use (base name, 'random', or .flf)")
+  var fontName: String?
+
+  @Argument(help: "Text to render. If omitted, reads from stdin when piped.")
+  var text: [String] = []
+
+  func run() throws {
+    if listFonts {
+      let names = SFKFonts.listNames()
+      if names.isEmpty { throw ValidationError("No bundled fonts found.") }
+      names.forEach { print($0) }
+      return
     }
-    return opts
-  }
 
-  static func printUsage() {
-    let exe = (CommandLine.arguments.first as NSString?)?.lastPathComponent ?? "swiftfiglet-cli"
-    let msg = """
-    Usage: \(exe) [options] <text>
+    if randomFontOnly {
+      guard let name = SFKFonts.randomName() else { throw ValidationError("No bundled fonts found.") }
+      print(name)
+      return
+    }
 
-    Options:
-      --font <name>         Use a specific font (base name or .flf)
-      --list-fonts          List bundled fonts and exit
-      -h, --help            Show this help message
+    let inputText = text.isEmpty ? readStdinIfPiped() : text.joined(separator: " ")
+    guard let message = inputText, !message.isEmpty else {
+      throw ValidationError("No text provided (arg or stdin).")
+    }
 
-    Examples:
-      \(exe) "Hello World"
-      \(exe) --font Standard "Banner"
-      echo hello | \(exe) --font Slant
-    """
-    print(msg)
+    // Resolve font URL (default to Standard)
+    let desired = fontName?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let fontURL: URL? = {
+      if let d = desired, !d.isEmpty {
+        if d.lowercased() == "random" { return SFKFonts.randomURL() }
+        return SFKFonts.find(d)
+      }
+      return SFKFonts.find("Standard")
+    }()
+    guard let url = fontURL else { throw ValidationError("Unknown or unavailable font: \(desired ?? "(nil)")") }
+    guard let font = SFKFont.from(url: url) else { throw ValidationError("Failed to load font at \(url.path)") }
+
+    print(string: message, usingFont: font)
   }
 }
 
-func readStdinIfPiped() -> String? {
-  // If stdin is not a TTY, read it
+private func readStdinIfPiped() -> String? {
   if isatty(fileno(stdin)) == 0 {
     let data = FileHandle.standardInput.readDataToEndOfFile()
     if let s = String(data: data, encoding: .utf8) {
@@ -62,47 +66,3 @@ func readStdinIfPiped() -> String? {
   }
   return nil
 }
-
-func run() -> Int32 {
-  let args = Array(CommandLine.arguments.dropFirst())
-  let opts = CLI.parse(args)
-
-  if opts.listFonts {
-    let names = SFKFonts.listNames()
-    if names.isEmpty {
-      fputs("No bundled fonts found.\n", stderr)
-      return 1
-    }
-    for n in names { print(n) }
-    return 0
-  }
-
-  let inputText = opts.text ?? readStdinIfPiped()
-  guard let text = inputText, !text.isEmpty else {
-    CLI.printUsage()
-    return 1
-  }
-
-  // Resolve font URL
-  let fontURL: URL?
-  if let name = opts.fontName, !name.isEmpty {
-    fontURL = SFKFonts.find(name)
-    if fontURL == nil {
-      fputs("Unknown font: \(name)\n", stderr)
-      return 2
-    }
-  } else {
-    // Default to Standard
-    fontURL = SFKFonts.find("Standard")
-  }
-
-  guard let url = fontURL, let font = SFKFont.from(url: url) else {
-    fputs("Failed to load font.\n", stderr)
-    return 3
-  }
-
-  print(string: text, usingFont: font)
-  return 0
-}
-
-exit(run())

--- a/Sources/SwiftFigletCLI/main.swift
+++ b/Sources/SwiftFigletCLI/main.swift
@@ -1,0 +1,109 @@
+import Foundation
+import SwiftFigletKit
+
+struct CLI {
+  struct Options {
+    var listFonts = false
+    var fontName: String? = nil
+    var text: String? = nil
+  }
+
+  static func parse(_ args: [String]) -> Options {
+    var opts = Options()
+    var i = 0
+    while i < args.count {
+      let a = args[i]
+      switch a {
+      case "-h", "--help":
+        printUsage()
+        exit(0)
+      case "-l", "--list-fonts":
+        opts.listFonts = true
+        i += 1
+      case "-f", "--font":
+        if i + 1 < args.count { opts.fontName = args[i + 1]; i += 2 } else { i += 1 }
+      default:
+        // Remaining args compose the text
+        let remaining = Array(args[i...])
+        opts.text = remaining.joined(separator: " ")
+        i = args.count
+      }
+    }
+    return opts
+  }
+
+  static func printUsage() {
+    let exe = (CommandLine.arguments.first as NSString?)?.lastPathComponent ?? "swiftfiglet"
+    let msg = """
+    Usage: \(exe) [options] <text>
+
+    Options:
+      -f, --font <name>     Use a specific font (base name or .flf)
+      -l, --list-fonts      List bundled fonts and exit
+      -h, --help            Show this help message
+
+    Examples:
+      \(exe) "Hello World"
+      \(exe) -f Standard "Banner"
+      echo hello | \(exe) -f Slant
+    """
+    print(msg)
+  }
+}
+
+func readStdinIfPiped() -> String? {
+  // If stdin is not a TTY, read it
+  if isatty(fileno(stdin)) == 0 {
+    let data = FileHandle.standardInput.readDataToEndOfFile()
+    if let s = String(data: data, encoding: .utf8) {
+      let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
+      return trimmed.isEmpty ? nil : trimmed
+    }
+  }
+  return nil
+}
+
+func run() -> Int32 {
+  let args = Array(CommandLine.arguments.dropFirst())
+  let opts = CLI.parse(args)
+
+  if opts.listFonts {
+    let names = SFKFonts.listNames()
+    if names.isEmpty {
+      fputs("No bundled fonts found.\n", stderr)
+      return 1
+    }
+    for n in names { print(n) }
+    return 0
+  }
+
+  let inputText = opts.text ?? readStdinIfPiped()
+  guard let text = inputText, !text.isEmpty else {
+    CLI.printUsage()
+    return 1
+  }
+
+  // Resolve font URL
+  let fontURL: URL?
+  if let name = opts.fontName, !name.isEmpty {
+    fontURL = SFKFonts.find(name)
+    if fontURL == nil {
+      fputs("Unknown font: \(name)\n", stderr)
+      return 2
+    }
+  } else {
+    // Default to Standard
+    fontURL = SFKFonts.find("Standard")
+  }
+
+  guard let url = fontURL, let font = SFKFont.from(url: url) else {
+    fputs("Failed to load font.\n", stderr)
+    return 3
+  }
+
+  print(string: text, usingFont: font)
+  return 0
+}
+
+exit(run())
+

--- a/Sources/SwiftFigletCLI/main.swift
+++ b/Sources/SwiftFigletCLI/main.swift
@@ -4,7 +4,7 @@ import SwiftFigletKit
 
 @main
 struct SwiftFigletCLI: ParsableCommand {
-  static var configuration = CommandConfiguration(
+  static let configuration = CommandConfiguration(
     commandName: "swift-figlet-cli",
     abstract: "Render text using bundled FIGlet fonts"
   )

--- a/Sources/SwiftFigletCLI/main.swift
+++ b/Sources/SwiftFigletCLI/main.swift
@@ -1,5 +1,5 @@
-import Foundation
 import ArgumentParser
+import Foundation
 import SwiftFigletKit
 
 @main
@@ -30,7 +30,9 @@ struct SwiftFigletCLI: ParsableCommand {
     }
 
     if randomFontOnly {
-      guard let name = SFKFonts.randomName() else { throw ValidationError("No bundled fonts found.") }
+      guard let name = SFKFonts.randomName() else {
+        throw ValidationError("No bundled fonts found.")
+      }
       print(name)
       return
     }
@@ -49,8 +51,12 @@ struct SwiftFigletCLI: ParsableCommand {
       }
       return SFKFonts.find("Standard")
     }()
-    guard let url = fontURL else { throw ValidationError("Unknown or unavailable font: \(desired ?? "(nil)")") }
-    guard let font = SFKFont.from(url: url) else { throw ValidationError("Failed to load font at \(url.path)") }
+    guard let url = fontURL else {
+      throw ValidationError("Unknown or unavailable font: \(desired ?? "(nil)")")
+    }
+    guard let font = SFKFont.from(url: url) else {
+      throw ValidationError("Failed to load font at \(url.path)")
+    }
 
     print(string: message, usingFont: font)
   }

--- a/Sources/SwiftFigletCLI/main.swift
+++ b/Sources/SwiftFigletCLI/main.swift
@@ -38,14 +38,14 @@ struct CLI {
     Usage: \(exe) [options] <text>
 
     Options:
-      -f, --font <name>     Use a specific font (base name or .flf)
-      -l, --list-fonts      List bundled fonts and exit
+      --font <name>         Use a specific font (base name or .flf)
+      --list-fonts          List bundled fonts and exit
       -h, --help            Show this help message
 
     Examples:
       \(exe) "Hello World"
-      \(exe) -f Standard "Banner"
-      echo hello | \(exe) -f Slant
+      \(exe) --font Standard "Banner"
+      echo hello | \(exe) --font Slant
     """
     print(msg)
   }

--- a/Sources/SwiftFigletKit/Resources/README.md
+++ b/Sources/SwiftFigletKit/Resources/README.md
@@ -4,7 +4,7 @@
 ╹  ╹┗━┛┗━╸┗━╸ ╹    ╹  ┗━┛╹ ╹ ╹ ┗━┛
 ```
 
-my collection of ascii art fonts for [figlet](http://www.figlet.org/) or [toilet](http://caca.zoy.org/wiki/toilet). 
+my collection of ascii art fonts for [figlet](http://www.figlet.org/) or
+[toilet](http://caca.zoy.org/wiki/toilet).
 
 install files to `/usr/share/figlet/` or `/usr/share/figlet/fonts/`.
-

--- a/Sources/SwiftFigletKit/SFKANSI.swift
+++ b/Sources/SwiftFigletKit/SFKANSI.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// ANSI color utilities for SwiftFigletKit banners.
+public enum SFKANSI {
+  public enum Color: String, Sendable {
+    case none, black, red, green, yellow, blue, magenta, cyan, white
+  }
+
+  /// Wrap text in ANSI color codes when appropriate.
+  /// - Parameters:
+  ///   - text: The text to wrap.
+  ///   - color: The desired ANSI color.
+  ///   - force: When true, always apply ANSI codes even in Xcode sessions.
+  ///   - disableInXcode: When true, suppress ANSI codes if running under Xcode.
+  public static func wrap(
+    _ text: String,
+    color: Color,
+    force: Bool = false,
+    disableInXcode: Bool = true
+  ) -> String {
+    if color == .none { return text }
+    if disableInXcode && !force
+      && ProcessInfo.processInfo.environment["__XCODE_BUILT_PRODUCTS_DIR_PATHS"] != nil
+    {
+      return text
+    }
+    let code: String = {
+      switch color {
+      case .none: return ""
+      case .black: return "\u{001B}[30m"
+      case .red: return "\u{001B}[31m"
+      case .green: return "\u{001B}[32m"
+      case .yellow: return "\u{001B}[33m"
+      case .blue: return "\u{001B}[34m"
+      case .magenta: return "\u{001B}[35m"
+      case .cyan: return "\u{001B}[36m"
+      case .white: return "\u{001B}[37m"
+      }
+    }()
+    return code + text + "\u{001B}[0m"
+  }
+}

--- a/Sources/SwiftFigletKit/SFKChar.swift
+++ b/Sources/SwiftFigletKit/SFKChar.swift
@@ -31,7 +31,7 @@ import Foundation
 ///  #  $@
 /// #####$@
 /// ```
-public struct SFKChar {
+public struct SFKChar: Sendable {
   /// Represents an empty Character
   public static let emptyChar: SFKChar = .init(charLines: [])
 

--- a/Sources/SwiftFigletKit/SFKFigletFile.swift
+++ b/Sources/SwiftFigletKit/SFKFigletFile.swift
@@ -69,8 +69,8 @@ public struct SFKFigletFile {
     public let fullLayout: Int
     public let codeTagCount: Int
 
-    /// Returns a Header from String passed. If can't create it because `from` does not follow
-    /// Figlet header format, returns `nil`
+    /// Returns a Header from the String passed. If it can't create it because `from` does not follow
+    /// the Figlet header format, returns `nil`
     /// - Parameter header: first line from a Figlet font file
     public static func createFigletFontHeader(from header: String) -> Self? {
       let headerParts = header.components(separatedBy: " ")

--- a/Sources/SwiftFigletKit/SFKFigletFile.swift
+++ b/Sources/SwiftFigletKit/SFKFigletFile.swift
@@ -32,15 +32,15 @@ public struct SFKFigletFile {
 
   /**
     Figlet file header
-
+  
     ```
     From: http://www.jave.de/docs/figfont.txt
-
+  
     THE HEADER LINE
-
+  
     The header line gives information about the FIGfont.  Here is an example
     showing the names of all parameters:
-
+  
               flf2a$ 6 5 20 15 3 0 143 229    NOTE: The first five characters in
                 |  | | | |  |  | |  |   |     the entire file must be "flf2a".
                /  /  | | |  |  | |  |   \
@@ -49,7 +49,7 @@ public struct SFKFigletFile {
              Height  /   |  |   \  Print_Direction
              Baseline   /    \   Comment_Lines
               Max_Length      Old_Layout*
-
+  
       * The two layout parameters are closely related and fairly complex.
           (See "INTERPRETATION OF LAYOUT PARAMETERS".)
     ```
@@ -103,7 +103,7 @@ public struct SFKFigletFile {
         commentLines: commentLines,
         commentDirection: commentDirection,
         fullLayout: fullLayout,
-        codeTagCount: codeTagCount
+        codeTagCount: codeTagCount,
       )
     }
   }
@@ -148,7 +148,7 @@ public struct SFKFigletFile {
         // we try to split each line using Windows line terminator style
         // some font files have mixed line endings
         let splittedLine = line.split(
-          separator: CRLF.windowsStyle.rawValue, omittingEmptySubsequences: false
+          separator: CRLF.windowsStyle.rawValue, omittingEmptySubsequences: false,
         )
         for sl in splittedLine {
           finalLines.append(sl)

--- a/Sources/SwiftFigletKit/SFKFigletFile.swift
+++ b/Sources/SwiftFigletKit/SFKFigletFile.swift
@@ -138,43 +138,38 @@ public struct SFKFigletFile {
   /// - Parameter fileURL: URL pointing to the file.
   /// - Returns: a`SFKFigletFile` object containing the file or `nil` if there was an error
   public static func from(url fileURL: URL) -> Self? {
-    do {
-      // Try multiple encodings to handle comments with non‑ASCII characters.
-      let text: String
-      if let s = try? String(contentsOf: fileURL, encoding: .utf8) {
-        text = s
-      } else if let s = try? String(contentsOf: fileURL, encoding: .ascii) {
-        text = s
-      } else if let s = try? String(contentsOf: fileURL, encoding: .isoLatin1) {
-        text = s
-      } else {
-        return nil
-      }
-
-      // Normalize line endings to LF so downstream parsing is deterministic.
-      let normalized = text
-        .replacingOccurrences(of: LineEnding.crlf, with: LineEnding.lf)
-        .replacingOccurrences(of: LineEnding.cr, with: LineEnding.lf)
-
-      // Split into lines; keep empty lines for vertical spacing.
-      let lines = normalized.split(separator: "\n", omittingEmptySubsequences: false)
-
-      guard let header = Header.createFigletFontHeader(from: String(lines.first ?? "")) else {
-        // can't extract header
-        return nil
-      }
-      var headerLines: [Substring] = []
-      for i in 0...header.commentLines {
-        headerLines.append(lines[i])
-      }
-
-      // lines describing characters start after: 1 line header + header.commentLines
-      let characterLines = Array(lines.dropFirst(header.commentLines + 1))
-      return .init(header: header, headerLines: headerLines, lines: characterLines)
-    } catch {
-      // errors opening file
+    // Try multiple encodings to handle comments with non‑ASCII characters.
+    let text: String
+    if let s = try? String(contentsOf: fileURL, encoding: .utf8) {
+      text = s
+    } else if let s = try? String(contentsOf: fileURL, encoding: .ascii) {
+      text = s
+    } else if let s = try? String(contentsOf: fileURL, encoding: .isoLatin1) {
+      text = s
+    } else {
       return nil
     }
+
+    // Normalize line endings to LF so downstream parsing is deterministic.
+    let normalized = text
+      .replacingOccurrences(of: LineEnding.crlf, with: LineEnding.lf)
+      .replacingOccurrences(of: LineEnding.cr, with: LineEnding.lf)
+
+    // Split into lines; keep empty lines for vertical spacing.
+    let lines = normalized.split(separator: "\n", omittingEmptySubsequences: false)
+
+    guard let header = Header.createFigletFontHeader(from: String(lines.first ?? "")) else {
+      // can't extract header
+      return nil
+    }
+    var headerLines: [Substring] = []
+    for i in 0...header.commentLines {
+      headerLines.append(lines[i])
+    }
+
+    // lines describing characters start after: 1 line header + header.commentLines
+    let characterLines = Array(lines.dropFirst(header.commentLines + 1))
+    return .init(header: header, headerLines: headerLines, lines: characterLines)
   }
 }
 

--- a/Sources/SwiftFigletKit/SFKFont.swift
+++ b/Sources/SwiftFigletKit/SFKFont.swift
@@ -92,21 +92,25 @@ extension SFKFont {
 
     var nextASCIIChar = 32  // 32 is Space
 
-    //        let separator = figletFile.characterLineTerminator()
+    let terminator: Character = figletFile.characterLineTerminator()
 
     var arrayLines: [String] = []
 
     for line in figletFile.lines {
-      let fontLine: Substring =
-        if arrayLines.count < font.height - 1 {
-          // remove last @
-          line.dropLast()
-        } else {
-          // remove last @@
-          line.dropLast().dropLast()
-        }
+      // Trim trailing CR first (when fonts used CRLF originally)
+      var trimmed = line
+      if trimmed.last == "\r" { trimmed = trimmed.dropLast() }
+
+      // Remove the line terminator: on the last line of a character it's doubled.
+      let neededDrops = (arrayLines.count < font.height - 1) ? 1 : 2
+      var drops = neededDrops
+      while drops > 0, let last = trimmed.last, last == terminator {
+        trimmed = trimmed.dropLast()
+        drops -= 1
+      }
+
       arrayLines.append(
-        String(fontLine.replacingOccurrences(of: String(figletFile.header.hardBlank), with: " ")))
+        String(trimmed.replacingOccurrences(of: String(figletFile.header.hardBlank), with: " ")))
 
       // last line
       if arrayLines.count == font.height {

--- a/Sources/SwiftFigletKit/SFKFont.swift
+++ b/Sources/SwiftFigletKit/SFKFont.swift
@@ -54,7 +54,7 @@ extension SFKFont {
     let enumerator = FileManager.default.enumerator(
       at: resourceURL!,
       includingPropertiesForKeys: [.isRegularFileKey],
-      options: [.skipsHiddenFiles]
+      options: [.skipsHiddenFiles],
     )
 
     var fonts: [SFKFont] = []

--- a/Sources/SwiftFigletKit/SFKFont.swift
+++ b/Sources/SwiftFigletKit/SFKFont.swift
@@ -50,7 +50,6 @@ public struct SFKFont {
 extension SFKFont {
   public static func random() -> SFKFont? {
     let resourceURL = Bundle.module.resourceURL
-    resourceURL!.absoluteString.replacingOccurrences(of: "file://", with: "")
     let enumerator = FileManager.default.enumerator(
       at: resourceURL!,
       includingPropertiesForKeys: [.isRegularFileKey],

--- a/Sources/SwiftFigletKit/SFKFonts.swift
+++ b/Sources/SwiftFigletKit/SFKFonts.swift
@@ -26,6 +26,16 @@ public enum SFKFonts {
       .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
   }
 
+  /// Returns a random bundled font name.
+  public static func randomName() -> String? {
+    listNames().randomElement()
+  }
+
+  /// Returns a random bundled font URL.
+  public static func randomURL() -> URL? {
+    all().randomElement()
+  }
+
   /// Finds a font URL by name. Accepts either a base name or filename with extension.
   /// Comparison is case-insensitive; space and underscore differences are tolerated.
   public static func find(_ name: String) -> URL? {
@@ -46,4 +56,3 @@ public enum SFKFonts {
       .lowercased()
   }
 }
-

--- a/Sources/SwiftFigletKit/SFKFonts.swift
+++ b/Sources/SwiftFigletKit/SFKFonts.swift
@@ -1,0 +1,49 @@
+//
+//  SFKFonts.swift
+//  SwiftFigletKit
+//
+//  Lightweight helper to access bundled FIGlet fonts.
+
+import Foundation
+
+public enum SFKFonts {
+  /// Returns URLs for all bundled `.flf` fonts.
+  public static func all() -> [URL] {
+    guard let root = Bundle.module.resourceURL?.appendingPathComponent("Fonts", isDirectory: true)
+    else { return [] }
+
+    let fm = FileManager.default
+    guard let items = try? fm.contentsOfDirectory(at: root, includingPropertiesForKeys: nil) else {
+      return []
+    }
+    return items.filter { $0.pathExtension.lowercased() == "flf" }
+  }
+
+  /// Lists all bundled font display names (without extension), sorted A–Z.
+  public static func listNames() -> [String] {
+    all()
+      .map { $0.deletingPathExtension().lastPathComponent }
+      .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+  }
+
+  /// Finds a font URL by name. Accepts either a base name or filename with extension.
+  /// Comparison is case-insensitive; space and underscore differences are tolerated.
+  public static func find(_ name: String) -> URL? {
+    let wanted = normalize(name)
+    for url in all() {
+      let base = url.deletingPathExtension().lastPathComponent
+      let withExt = url.lastPathComponent
+      if normalize(base) == wanted || normalize(withExt) == wanted {
+        return url
+      }
+    }
+    return nil
+  }
+
+  private static func normalize(_ s: String) -> String {
+    s.replacingOccurrences(of: "_", with: " ")
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .lowercased()
+  }
+}
+

--- a/Sources/SwiftFigletKit/SFKRandomRendering.swift
+++ b/Sources/SwiftFigletKit/SFKRandomRendering.swift
@@ -1,0 +1,217 @@
+import Foundation
+
+// MARK: - Public strategies and options
+
+/// Strategy to choose which FIGlet font to use.
+public enum SFKFontStrategy: Sendable {
+  /// Use a specific font name (case-insensitive; accepts base name or `.flf`).
+  case named(String)
+  /// Choose a random font, optionally excluding some names.
+  case random(excluding: [String] = [])
+}
+
+/// Strategy to colorize output when rendering banners.
+public enum SFKColorStrategy: Sendable {
+  /// Render with a single ANSI color.
+  case single(SFKRenderer.ANSIColor)
+  /// Pick a single color randomly from a palette (defaults to `SFKPalettes.singleDefault`).
+  case singleRandom(palette: [SFKRenderer.ANSIColor]? = nil)
+  /// Render with a fixed palette across lines, cycling colors per line.
+  case gradient(palette: [SFKRenderer.ANSIColor])
+  /// Pick a gradient palette (or use default) and optionally shuffle it.
+  case gradientRandom(palette: [SFKRenderer.ANSIColor]? = nil, shuffle: Bool = true)
+  /// Choose between single and gradient at runtime with a probability.
+  case mixedRandom(
+    gradientProbability: Double = 0.5,
+    singlePalette: [SFKRenderer.ANSIColor]? = nil,
+    gradientPalette: [SFKRenderer.ANSIColor]? = nil
+  )
+}
+
+/// Rendering options for high-level banner helpers.
+public struct SFKRenderOptions: Sendable {
+  /// Optional string placed before the rendered text.
+  public var prefix: String? = nil
+  /// Optional string placed after the rendered text.
+  public var suffix: String? = nil
+  /// When true, appends a trailing newline when falling back to plain text.
+  public var newline: Bool = false
+  /// Reserved for future use (no wrapping currently performed).
+  public var wrapWidth: Int? = nil // reserved for future use
+  /// Optional seed for deterministic font/color selection across runs.
+  public var seed: UInt64? = nil
+  /// Force ANSI color even in Xcode consoles.
+  public var forceColor: Bool = false
+  /// Disable ANSI color in Xcode consoles (default true).
+  public var disableColorInXcode: Bool = true
+
+  public init(
+    prefix: String? = nil,
+    suffix: String? = nil,
+    newline: Bool = false,
+    wrapWidth: Int? = nil,
+    seed: UInt64? = nil,
+    forceColor: Bool = false,
+    disableColorInXcode: Bool = true
+  ) {
+    self.prefix = prefix
+    self.suffix = suffix
+    self.newline = newline
+    self.wrapWidth = wrapWidth
+    self.seed = seed
+    self.forceColor = forceColor
+    self.disableColorInXcode = disableColorInXcode
+  }
+}
+
+/// Default color palettes for single and gradient modes.
+public enum SFKPalettes {
+  /// Default palette for single-color rendering.
+  public static let singleDefault: [SFKRenderer.ANSIColor] =
+    [.red, .yellow, .green, .cyan, .blue, .magenta, .white]
+  /// Default palette for gradient rendering (cycled by line).
+  public static let gradientDefault: [SFKRenderer.ANSIColor] =
+    [.red, .yellow, .green, .cyan, .blue, .magenta]
+}
+
+// MARK: - Seeded RNG
+
+struct SFKSeededLCG: RandomNumberGenerator {
+  private var state: UInt64
+  init(seed: UInt64) { self.state = seed &* 6364136223846793005 &+ 1 }
+  mutating func next() -> UInt64 {
+    state = 2862933555777941757 &* state &+ 3037000493
+    return state
+  }
+}
+
+// MARK: - Rendering convenience
+
+extension SFKRenderer {
+  private static func toANSI(_ c: SFKRenderer.ANSIColor) -> SFKANSI.Color {
+    switch c {
+    case .none: return .none
+    case .black: return .black
+    case .red: return .red
+    case .green: return .green
+    case .yellow: return .yellow
+    case .blue: return .blue
+    case .magenta: return .magenta
+    case .cyan: return .cyan
+    case .white: return .white
+    }
+  }
+  /// High-level rendering combining font and color strategies with optional seeding.
+  ///
+  /// - Parameters:
+  ///   - text: The text to render.
+  ///   - font: Font selection strategy (named or random with exclusions).
+  ///   - color: Colorization strategy (single/gradient/random/mixed).
+  ///   - options: Rendering options (seed, prefix/suffix, color flags).
+  /// - Returns: A colored banner string. Falls back to a plain ANSI-colored line when fonts are unavailable.
+  public static func render(
+    text: String,
+    font: SFKFontStrategy,
+    color: SFKColorStrategy,
+    options: SFKRenderOptions = .init()
+  ) -> String {
+    // Resolve RNG
+    let rng = options.seed.map { SFKSeededLCG(seed: $0) }
+
+    // Resolve font URL or object
+    let chosenFontURL: URL? = {
+      switch font {
+      case .named(let name):
+        return SFKFonts.find(name)
+      case .random(let excluding):
+        let all = SFKFonts.listNames().filter { !excluding.contains($0) }
+        guard !all.isEmpty else { return SFKFonts.randomURL() }
+        if var rr = rng {
+          let idx = Int(rr.next() % UInt64(all.count))
+          return SFKFonts.find(all[idx])
+        } else {
+          return SFKFonts.find(all.randomElement() ?? "")
+        }
+      }
+    }()
+
+    // Load font if possible
+    let figlet: SFKFont? = chosenFontURL.flatMap { SFKFont.from(url: $0) }
+
+    // Prepare text with prefix/suffix
+    let combined: String = (options.prefix ?? "") + text + (options.suffix ?? "")
+
+    // Resolve color plan and render
+    switch color {
+    case .single(let c):
+      if let fig = figlet { return SFKRenderer.render(text: combined, using: fig, color: c, forceColor: options.forceColor, disableColorInXcode: options.disableColorInXcode) }
+      // Fallback: plain line with ANSI color
+      return SFKANSI.wrap(combined + (options.newline ? "\n" : ""), color: toANSI(c))
+
+    case .singleRandom(let palette):
+      let paletteToUse = palette ?? SFKPalettes.singleDefault
+      let color: SFKRenderer.ANSIColor = {
+        if var rr = rng { return paletteToUse[Int(rr.next() % UInt64(paletteToUse.count))] }
+        return paletteToUse.randomElement() ?? .white
+      }()
+      if let fig = figlet { return SFKRenderer.render(text: combined, using: fig, color: color, forceColor: options.forceColor, disableColorInXcode: options.disableColorInXcode) }
+      return SFKANSI.wrap(combined + (options.newline ? "\n" : ""), color: toANSI(color))
+
+    case .gradient(let palette):
+      if let fig = figlet {
+        let s = SFKRenderer.renderGradientLines(text: combined, using: fig, palette: palette, randomizePalette: false, forceColor: options.forceColor, disableColorInXcode: options.disableColorInXcode)
+        return options.newline ? s : s
+      }
+      // Fallback: map gradient to first color
+      let c = palette.first ?? .white
+      return SFKANSI.wrap(combined + (options.newline ? "\n" : ""), color: toANSI(c))
+
+    case .gradientRandom(let palette, let shuffle):
+      var pal = palette ?? SFKPalettes.gradientDefault
+      if shuffle {
+        if var rr = rng {
+          // Fisher–Yates with seeded RNG
+          for i in stride(from: pal.count - 1, through: 1, by: -1) {
+            let j = Int(rr.next() % UInt64(i + 1))
+            pal.swapAt(i, j)
+          }
+        } else {
+          pal.shuffle()
+        }
+      }
+      if let fig = figlet {
+        let s = SFKRenderer.renderGradientLines(text: combined, using: fig, palette: pal, randomizePalette: false, forceColor: options.forceColor, disableColorInXcode: options.disableColorInXcode)
+        return options.newline ? s : s
+      }
+      let c = pal.first ?? .white
+      return SFKANSI.wrap(combined + (options.newline ? "\n" : ""), color: toANSI(c))
+
+    case .mixedRandom(let p, let singlePal, let gradPal):
+      let threshold = max(0.0, min(1.0, p))
+      let chooseGradient: Bool = {
+        if var rr = rng { return (Double(rr.next() % 1_000_000) / 1_000_000.0) < threshold }
+        return Double.random(in: 0...1) < threshold
+      }()
+      if chooseGradient {
+        return render(text: text, font: font, color: .gradientRandom(palette: gradPal, shuffle: true), options: options)
+      } else {
+        return render(text: text, font: font, color: .singleRandom(palette: singlePal), options: options)
+      }
+    }
+  }
+
+  /// Convenience for typical banner use: random font with a mixed color strategy.
+  ///
+  /// - Parameters:
+  ///   - text: The text to render.
+  ///   - color: Color strategy. Defaults to a 50/50 single vs. gradient mix.
+  ///   - options: Rendering options; pass `seed` for deterministic output.
+  /// - Returns: A colored banner string or a plain ANSI-colored line if fonts are unavailable.
+  public static func renderRandomBanner(
+    text: String,
+    color: SFKColorStrategy = .mixedRandom(),
+    options: SFKRenderOptions = .init()
+  ) -> String {
+    render(text: text, font: .random(), color: color, options: options)
+  }
+}

--- a/Sources/SwiftFigletKit/SFKRenderer.swift
+++ b/Sources/SwiftFigletKit/SFKRenderer.swift
@@ -28,8 +28,11 @@ public enum SFKRenderer {
   public static func render(text: String, fontName name: String?) -> String? {
     let chosenURL: URL?
     if let name = name, !name.isEmpty {
-      if name.lowercased() == "random" { chosenURL = SFKFonts.randomURL() }
-      else { chosenURL = SFKFonts.find(name) }
+      if name.lowercased() == "random" {
+        chosenURL = SFKFonts.randomURL()
+      } else {
+        chosenURL = SFKFonts.find(name)
+      }
     } else {
       chosenURL = SFKFonts.find("Standard")
     }
@@ -37,4 +40,3 @@ public enum SFKRenderer {
     return render(text: text, fontURL: url)
   }
 }
-

--- a/Sources/SwiftFigletKit/SFKRenderer.swift
+++ b/Sources/SwiftFigletKit/SFKRenderer.swift
@@ -1,9 +1,17 @@
 import Foundation
 
+// Access ANSI utilities in this module
+// (same target, so no explicit import beyond module scope is needed)
+
 public enum SFKRenderer {
-  /// Render text using a previously loaded font.
-  public static func render(text: String, using font: SFKFont) -> String {
-    guard font.height > 0 else { return "" }
+  public enum ANSIColor: String, Sendable {
+    case none, black, red, green, yellow, blue, magenta, cyan, white
+  }
+  private static let defaultPalette: [ANSIColor] = [.red, .yellow, .green, .cyan, .blue, .magenta]
+
+  // Build lines for a given font
+  private static func buildLines(text: String, using font: SFKFont) -> [String] {
+    guard font.height > 0 else { return [] }
     var lines: [String] = Array(repeating: "", count: font.height)
     for i in 0..<font.height {
       var row = ""
@@ -14,18 +22,68 @@ public enum SFKRenderer {
       }
       lines[i] = row
     }
-    return lines.joined(separator: "\n") + "\n"
+    return lines
+  }
+  private static func wrap(_ text: String, color: ANSIColor, force: Bool, disableInXcode: Bool)
+    -> String
+  {
+    if color == .none { return text }
+    if disableInXcode && !force
+      && ProcessInfo.processInfo.environment["__XCODE_BUILT_PRODUCTS_DIR_PATHS"] != nil
+    {
+      return text
+    }
+    let code: String = {
+      switch color {
+      case .none: return ""
+      case .black: return "\u{001B}[30m"
+      case .red: return "\u{001B}[31m"
+      case .green: return "\u{001B}[32m"
+      case .yellow: return "\u{001B}[33m"
+      case .blue: return "\u{001B}[34m"
+      case .magenta: return "\u{001B}[35m"
+      case .cyan: return "\u{001B}[36m"
+      case .white: return "\u{001B}[37m"
+      }
+    }()
+    return code + text + "\u{001B}[0m"
+  }
+  /// Render text using a previously loaded font.
+  public static func render(
+    text: String,
+    using font: SFKFont,
+    color: ANSIColor = .none,
+    forceColor: Bool = false,
+    disableColorInXcode: Bool = true
+  ) -> String {
+    let lines = buildLines(text: text, using: font)
+    let rendered = lines.joined(separator: "\n") + "\n"
+    return wrap(rendered, color: color, force: forceColor, disableInXcode: disableColorInXcode)
   }
 
   /// Render text using a font at URL. Returns nil if loading fails.
-  public static func render(text: String, fontURL: URL) -> String? {
+  public static func render(
+    text: String,
+    fontURL: URL,
+    color: ANSIColor = .none,
+    forceColor: Bool = false,
+    disableColorInXcode: Bool = true
+  ) -> String? {
     guard let font = SFKFont.from(url: fontURL) else { return nil }
-    return render(text: text, using: font)
+    return render(
+      text: text, using: font, color: color, forceColor: forceColor,
+      disableColorInXcode: disableColorInXcode)
   }
 
   /// Render text using a named font (base name or .flf). Special name "random" uses a random font.
   /// Defaults to "Standard" when `name` is nil.
-  public static func render(text: String, fontName name: String?) -> String? {
+  public static func render(
+    text: String,
+    fontName name: String?,
+    color: ANSIColor = .none,
+    forceColor: Bool = false,
+    disableColorInXcode: Bool = true
+  ) -> String? {
     let chosenURL: URL?
     if let name = name, !name.isEmpty {
       if name.lowercased() == "random" {
@@ -37,6 +95,67 @@ public enum SFKRenderer {
       chosenURL = SFKFonts.find("Standard")
     }
     guard let url = chosenURL else { return nil }
-    return render(text: text, fontURL: url)
+    return render(
+      text: text,
+      fontURL: url,
+      color: color,
+      forceColor: forceColor,
+      disableColorInXcode: disableColorInXcode
+    )
+  }
+
+  /// Render using a gradient across lines.
+  public static func renderGradientLines(
+    text: String,
+    using font: SFKFont,
+    palette: [ANSIColor]? = nil,
+    randomizePalette: Bool = false,
+    forceColor: Bool = false,
+    disableColorInXcode: Bool = true
+  ) -> String {
+    let lines = buildLines(text: text, using: font)
+    var colors = palette ?? defaultPalette
+    if randomizePalette { colors.shuffle() }
+    guard !colors.isEmpty else { return lines.joined(separator: "\n") + "\n" }
+    let colored = lines.enumerated().map { (idx, line) in
+      wrap(
+        line, color: colors[idx % colors.count], force: forceColor,
+        disableInXcode: disableColorInXcode)
+    }
+    return colored.joined(separator: "\n") + "\n"
+  }
+
+  public static func renderGradientLines(
+    text: String,
+    fontURL: URL,
+    palette: [ANSIColor]? = nil,
+    randomizePalette: Bool = false,
+    forceColor: Bool = false,
+    disableColorInXcode: Bool = true
+  ) -> String? {
+    guard let font = SFKFont.from(url: fontURL) else { return nil }
+    return renderGradientLines(
+      text: text, using: font, palette: palette, randomizePalette: randomizePalette,
+      forceColor: forceColor, disableColorInXcode: disableColorInXcode)
+  }
+
+  public static func renderGradientLines(
+    text: String,
+    fontName name: String?,
+    palette: [ANSIColor]? = nil,
+    randomizePalette: Bool = false,
+    forceColor: Bool = false,
+    disableColorInXcode: Bool = true
+  ) -> String? {
+    let chosenURL: URL?
+    if let name, !name.isEmpty {
+      chosenURL = (name.lowercased() == "random") ? SFKFonts.randomURL() : SFKFonts.find(name)
+    } else {
+      chosenURL = SFKFonts.find("Standard")
+    }
+    guard let url = chosenURL else { return nil }
+    return renderGradientLines(
+      text: text, fontURL: url, palette: palette, randomizePalette: randomizePalette,
+      forceColor: forceColor, disableColorInXcode: disableColorInXcode)
   }
 }

--- a/Sources/SwiftFigletKit/SFKRenderer.swift
+++ b/Sources/SwiftFigletKit/SFKRenderer.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+public enum SFKRenderer {
+  /// Render text using a previously loaded font.
+  public static func render(text: String, using font: SFKFont) -> String {
+    guard font.height > 0 else { return "" }
+    var lines: [String] = Array(repeating: "", count: font.height)
+    for i in 0..<font.height {
+      var row = ""
+      for c in text {
+        if let ch = font.fkChar[c], i < ch.lines.count {
+          row += ch.lines[i]
+        }
+      }
+      lines[i] = row
+    }
+    return lines.joined(separator: "\n") + "\n"
+  }
+
+  /// Render text using a font at URL. Returns nil if loading fails.
+  public static func render(text: String, fontURL: URL) -> String? {
+    guard let font = SFKFont.from(url: fontURL) else { return nil }
+    return render(text: text, using: font)
+  }
+
+  /// Render text using a named font (base name or .flf). Special name "random" uses a random font.
+  /// Defaults to "Standard" when `name` is nil.
+  public static func render(text: String, fontName name: String?) -> String? {
+    let chosenURL: URL?
+    if let name = name, !name.isEmpty {
+      if name.lowercased() == "random" { chosenURL = SFKFonts.randomURL() }
+      else { chosenURL = SFKFonts.find(name) }
+    } else {
+      chosenURL = SFKFonts.find("Standard")
+    }
+    guard let url = chosenURL else { return nil }
+    return render(text: text, fontURL: url)
+  }
+}
+

--- a/Sources/SwiftFigletKit/SwiftFigletKit.docc/RandomRendering.md
+++ b/Sources/SwiftFigletKit/SwiftFigletKit.docc/RandomRendering.md
@@ -1,0 +1,61 @@
+# Random Rendering
+
+Learn how to render banners with random fonts and colors using ``SwiftFigletKit``.
+
+## Overview
+
+The high‑level APIs in ``SFKRenderer`` combine font selection and color strategies into a single
+call. You can:
+
+- Choose fonts by name or randomly (with exclusions) using ``SFKFontStrategy``.
+- Colorize with single or gradient styles, or mix randomly using ``SFKColorStrategy``.
+- Provide a seed for deterministic output via ``SFKRenderOptions``.
+
+When FIGlet fonts aren’t available, the APIs return a plain ANSI‑colored line so your app can still
+show a banner without failing.
+
+## Choose a Strategy
+
+- ``SFKFontStrategy``: ``SFKFontStrategy/named(_:)`` or ``SFKFontStrategy/random(excluding:)``
+- ``SFKColorStrategy``: ``SFKColorStrategy/single(_:)``,
+  ``SFKColorStrategy/singleRandom(palette:)``, ``SFKColorStrategy/gradient(palette:)``,
+  ``SFKColorStrategy/gradientRandom(palette:shuffle:)``,
+  ``SFKColorStrategy/mixedRandom(gradientProbability:singlePalette:gradientPalette:)``
+- ``SFKRenderOptions``: `prefix`, `suffix`, `newline`, `seed`, `forceColor`, `disableColorInXcode`
+
+## Render with a Random Font
+
+```swift
+import SwiftFigletKit
+
+let banner = SFKRenderer.renderRandomBanner(text: "Hello")
+print(banner)
+```
+
+## Fixed Font, Single Color
+
+```swift
+let out = SFKRenderer.render(
+  text: "Hello",
+  font: .named("Slant"),
+  color: .single(.cyan),
+  options: .init(newline: true)
+)
+```
+
+## Mixed Random Colors with Seed
+
+```swift
+let seed: UInt64 = 42
+let out = SFKRenderer.renderRandomBanner(
+  text: "Hello",
+  color: .mixedRandom(gradientProbability: 0.5),
+  options: .init(seed: seed)
+)
+```
+
+## Fallback Behavior
+
+If FIGlet fonts are unavailable, the functions return a single ANSI‑colored line. Gradient
+strategies degrade to a single color (first entry in the chosen palette).
+

--- a/Sources/SwiftFigletKit/SwiftFigletKit.docc/SwiftFigletKit.md
+++ b/Sources/SwiftFigletKit/SwiftFigletKit.docc/SwiftFigletKit.md
@@ -1,0 +1,18 @@
+# ``SwiftFigletKit``
+
+SwiftFigletKit renders FIGlet banners in Swift. It includes bundled fonts, ANSI color utilities, and
+helpers for gradients and random banner rendering.
+
+## Overview
+
+Use ``SFKRenderer`` to render text using FIGlet fonts discovered from the bundled resources. ANSI
+color utilities enable single‑color output or simple gradients across lines. The high‑level random
+rendering APIs let you pick a random font and color strategy, with optional seeding for
+deterministic output.
+
+## Topics
+
+### Random Rendering
+
+- <doc:RandomRendering>
+

--- a/Tests/SwiftFigletKitTests/SFKFigletFileTests.swift
+++ b/Tests/SwiftFigletKitTests/SFKFigletFileTests.swift
@@ -1,5 +1,5 @@
-import Testing
 import Foundation
+import Testing
 
 @testable import SwiftFigletKit
 

--- a/Tests/SwiftFigletKitTests/SFKFontTests.swift
+++ b/Tests/SwiftFigletKitTests/SFKFontTests.swift
@@ -5,8 +5,8 @@
 //  Created by Diego Freniche Brito on 10/05/2020.
 //
 
-import Testing
 import Foundation
+import Testing
 
 @testable import SwiftFigletKit
 

--- a/Tests/SwiftFigletKitTests/XCTestManifests.swift
+++ b/Tests/SwiftFigletKitTests/XCTestManifests.swift
@@ -1,9 +1,9 @@
 import XCTest
 
 #if !canImport(ObjectiveC)
-public func allTests() -> [XCTestCaseEntry] {
-  [
-    testCase(SwiftFigletKitTests.allTests)
-  ]
-}
+  public func allTests() -> [XCTestCaseEntry] {
+    [
+      testCase(SwiftFigletKitTests.allTests)
+    ]
+  }
 #endif


### PR DESCRIPTION
This pull request introduces several significant updates to the SwiftFigletKit project, focusing on improved font handling, new CLI support, color/gradient rendering, and enhanced documentation. The changes modernize the package for Swift 6.1, add a command-line interface, enable ANSI color and gradient output, and make font parsing more robust across platforms and encodings.

**New CLI and Package enhancements**
* Added a new executable target `SwiftFigletCLI` with a command-line interface supporting font listing, random font selection, and text rendering via bundled FIGlet fonts. The CLI uses Swift Argument Parser and includes a motivational "greet" subcommand. (`Package.swift`, `Sources/SwiftFigletCLI/SwiftFigletCLI.swift`) [[1]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL13-R19) [[2]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eR30-R46) [[3]](diffhunk://#diff-b244f8b268475145fa8b4fea80902f24f4f3174a697b22dc3bf3b9197c6453b8R1-R123)

**Color and gradient rendering**
* Introduced ANSI color helpers (`SFKANSI`) and new rendering APIs for single color, gradients, and random color strategies. These are documented with usage examples and options for disabling color in Xcode or forcing color output. (`Sources/SwiftFigletKit/SFKANSI.swift`, `README.md`) [[1]](diffhunk://#diff-47f6ed0693a4e3ca28168479454e054e33f33abfbd6c637d36393299251b4ccfR1-R42) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R166)

**Font parsing and resource improvements**
* Improved Figlet font file parsing: now supports multiple encodings (UTF-8, ASCII, Latin1), normalizes line endings for reliable cross-platform parsing, and robustly detects character terminators even with mixed line endings. (`Sources/SwiftFigletKit/SFKFigletFile.swift`, `Sources/SwiftFigletKit/SFKFont.swift`) [[1]](diffhunk://#diff-2c45731a55b480241851d8571f75488d72a013e5a5ad615951a5db37231e03f0L138-R159) [[2]](diffhunk://#diff-2c45731a55b480241851d8571f75488d72a013e5a5ad615951a5db37231e03f0L118-R124) [[3]](diffhunk://#diff-7b2f938d30d12644abc2fa0b36ccedb2e47275312ce06ce8298928b0e02b58feL96-R113)
* Fonts are now bundled as SwiftPM resources and discovered via `Bundle.module`, enabling easier integration and random font selection. (`README.md`, `Package.swift`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R166) [[2]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eR30-R46)

**Documentation and project structure**
* Major README overhaul: added CLI instructions, color/gradient usage, randomization APIs, fallback behaviors, and links to DocC documentation. Font README was moved and updated for clarity. (`README.md`, `Docs/Fonts-README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R166) [[2]](diffhunk://#diff-945933926cf8f30440a7a1dbbc05780060b324274c00008cd18403895d07d716L7-L10)
* Updated SwiftPM manifest for Swift 6.1, added new dependencies, and improved test target resource handling. (`Package.swift`) [[1]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL1-R1) [[2]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eR30-R46)

**Miscellaneous fixes and improvements**
* Minor code quality improvements: made `SFKChar` conform to `Sendable`, fixed typos, improved header parsing, and updated Xcode workspace data and scheme version. (`Sources/SwiftFigletKit/SFKChar.swift`, `.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata`, `.swiftpm/xcode/xcshareddata/xcschemes/SwiftFigletKit.xcscheme`) [[1]](diffhunk://#diff-c982451f846cf8a10133f0c71690311401e7c2d0cfaf989a79b34f733efb78e9L34-R34) [[2]](diffhunk://#diff-129f08f050d3ef79c2f2e16623a5b2d43c9c653ef2f06f42eddb7bdef1af6a08R1-R4) [[3]](diffhunk://#diff-aab92164130acc5dd0857f96bfbb1c71330baabc0d451cb663b25bb01c2e22baL3-R3)